### PR TITLE
Fix daily news automation PR flow

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -49,11 +49,12 @@ jobs:
         run: npm run build
 
       - name: Create pull request
+        id: create-pull-request
         uses: peter-evans/create-pull-request@v8
         with:
           base: master
-          branch: automation/daily-news
-          delete-branch: false
+          branch: automation/daily-news-${{ steps.edition-date.outputs.edition_date }}
+          delete-branch: true
           commit-message: "Add daily news for ${{ steps.edition-date.outputs.edition_date }}"
           title: "Add daily news for ${{ steps.edition-date.outputs.edition_date }}"
           body: |
@@ -63,3 +64,9 @@ jobs:
           labels: |
             automation
             daily-news
+
+      - name: Merge pull request
+        if: steps.create-pull-request.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge "${{ steps.create-pull-request.outputs.pull-request-number }}" --squash --delete-branch


### PR DESCRIPTION
## Summary
- Use date-specific daily news automation branches so pending runs cannot overwrite older PRs.
- Auto-merge generated daily news PRs after creation and delete the automation branch.

## Validation
- `npm run lint --if-present`
- `npm test`
- `npm run build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-news.yml"); puts "daily-news.yml YAML OK"'`
- `git diff --check`