### PR TITLE
Dispatch deploy after daily news merge

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -70,3 +71,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr merge "${{ steps.create-pull-request.outputs.pull-request-number }}" --squash --delete-branch
+
+      - name: Dispatch deploy workflow
+        if: steps.create-pull-request.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run main.yml --ref master


### PR DESCRIPTION
## Summary
- Grant the Daily News workflow Actions write permission so it can dispatch another workflow.
- Dispatch the existing CI deploy workflow on `master` after an automated Daily News PR is merged.

## Validation
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/daily-news.yml\"); puts \"YAML OK\""`
- `npm run lint --if-present`
- `npm test`
- `npm run build`