### PR TITLE
Improve password generator theme styling

### DIFF
--- a/site/pages/projects/password-generator.js
+++ b/site/pages/projects/password-generator.js
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import DEFAULT_CONFIG from '../../config/default_config';
 import Layout from "../../components/layout";
 import utilStyles from "../../styles/utils.module.scss";
+import styles from "../../styles/password-generator.module.scss";
 import { projectsList } from "../../config/projectsList";
 
 const LENGTH_PRESETS = [8, 16, 32, 64];
@@ -184,63 +185,66 @@ export default function PasswordGeneratorPage() {
         <meta name="twitter:image:alt" content={ meta.title } />
       </Head>
 
-      <article>
-        <h2 className={utilStyles.headingLg}>Password Generator</h2>
+      <article className={styles.page}>
+        <h2 className={`${utilStyles.headingLg} ${styles.title}`}>Password Generator</h2>
 
-        <div className="mt-6 rounded-lg border border-gray-800 bg-gray-950/40 p-5">
-          <label className="block text-sm font-semibold text-gray-300" htmlFor="generated-password">
-            Generated password
-          </label>
-          <div className="mt-3 grid gap-3 md:grid-cols-[1fr_auto_auto]">
+        <section className={`${styles.panel} ${styles.outputPanel}`}>
+          <div className={styles.outputHeader}>
+            <label className={styles.panelLabel} htmlFor="generated-password">
+              Generated password
+            </label>
+            <div className={styles.actions}>
+              <button
+                type="button"
+                onClick={copyPassword}
+                className={`${styles.actionButton} ${styles.secondaryAction}`}
+              >
+                {copyState}
+              </button>
+              <button
+                type="button"
+                onClick={regenerate}
+                className={`${styles.actionButton} ${styles.primaryAction}`}
+              >
+                Generate
+              </button>
+            </div>
+          </div>
+
+          <div className={styles.passwordField}>
             <textarea
               id="generated-password"
               value={password}
               readOnly
               rows={4}
-              className="min-h-[120px] w-full resize-y rounded-lg border border-gray-800 bg-gray-900 px-4 py-3 font-mono text-lg text-sky-200 outline-none focus:ring-2 focus:ring-sky-400/50"
+              className={styles.passwordTextarea}
             />
-            <button
-              type="button"
-              onClick={copyPassword}
-              className="h-12 rounded-lg bg-sky-600 px-5 text-sm font-semibold text-white transition-colors hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-300"
-            >
-              {copyState}
-            </button>
-            <button
-              type="button"
-              onClick={regenerate}
-              className="h-12 rounded-lg bg-emerald-600 px-5 text-sm font-semibold text-white transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-300"
-            >
-              Generate
-            </button>
           </div>
 
           {error && (
-            <div className="mt-3 rounded-md border border-rose-900 bg-rose-950/40 px-3 py-2 text-sm text-rose-300">
+            <div className={styles.errorMessage}>
               {error}
             </div>
           )}
 
-          <div className="mt-3 flex flex-wrap gap-3 text-sm text-gray-400">
-            <span>Length: {length}</span>
-            <span>Entropy: {entropyBits} bits</span>
-            {useHexDigest && <span>Hex digest</span>}
+          <div className={styles.metaBar}>
+            <span className={styles.metaPill}>Length: {length}</span>
+            <span className={styles.metaPill}>Entropy: {entropyBits} bits</span>
+            {useHexDigest && <span className={styles.metaPill}>Hex digest</span>}
           </div>
-        </div>
+        </section>
 
-        <div className="mt-6 grid gap-6 md:grid-cols-2">
-          <section className="rounded-lg border border-gray-800 bg-gray-950/40 p-5">
-            <h3 className="text-lg font-semibold text-gray-100">Length</h3>
-            <div className="mt-4 grid grid-cols-4 gap-2">
+        <div className={styles.controlGrid}>
+          <section className={styles.panel}>
+            <h3 className={styles.sectionTitle}>Length</h3>
+            <div className={styles.presetGrid}>
               {LENGTH_PRESETS.map((preset) => (
                 <button
                   type="button"
                   key={preset}
                   onClick={() => selectPreset(preset)}
-                  className={`rounded-lg border px-3 py-2 text-sm font-semibold transition-colors ${
-                    activePreset === preset
-                      ? "border-sky-400 bg-sky-600 text-white"
-                      : "border-gray-700 bg-gray-900 text-gray-300 hover:border-gray-500"
+                  className={`${styles.presetButton} ${
+                    activePreset === preset ? styles.presetActive : ""
                   }`}
                 >
                   {preset}
@@ -248,7 +252,7 @@ export default function PasswordGeneratorPage() {
               ))}
             </div>
 
-            <label className="mt-5 block text-sm font-semibold text-gray-300" htmlFor="custom-length">
+            <label className={styles.fieldLabel} htmlFor="custom-length">
               Custom length
             </label>
             <input
@@ -258,13 +262,13 @@ export default function PasswordGeneratorPage() {
               max={MAX_LENGTH}
               value={customLength}
               onChange={(event) => updateCustomLength(event.target.value)}
-              className="mt-2 w-full rounded-lg border border-gray-800 bg-gray-900 px-4 py-3 text-lg text-gray-100 outline-none focus:ring-2 focus:ring-sky-400/50"
+              className={styles.numberInput}
             />
           </section>
 
-          <section className="rounded-lg border border-gray-800 bg-gray-950/40 p-5">
-            <h3 className="text-lg font-semibold text-gray-100">Characters</h3>
-            <div className="mt-4 grid gap-3">
+          <section className={styles.panel}>
+            <h3 className={styles.sectionTitle}>Characters</h3>
+            <div className={styles.optionStack}>
               {[
                 ["uppercase", "Uppercase"],
                 ["lowercase", "Lowercase"],
@@ -273,27 +277,29 @@ export default function PasswordGeneratorPage() {
               ].map(([key, label]) => (
                 <label
                   key={key}
-                  className="flex items-center justify-between rounded-lg border border-gray-800 bg-gray-900 px-4 py-3"
+                  className={`${styles.optionRow} ${
+                    useHexDigest ? styles.optionDisabled : ""
+                  }`}
                 >
-                  <span className="text-sm font-semibold text-gray-200">{label}</span>
+                  <span className={styles.optionLabel}>{label}</span>
                   <input
                     type="checkbox"
                     checked={options[key]}
                     disabled={useHexDigest}
                     onChange={() => toggleOption(key)}
-                    className="h-5 w-5 accent-sky-500"
+                    className={styles.checkbox}
                   />
                 </label>
               ))}
             </div>
 
-            <label className="mt-5 flex items-center justify-between rounded-lg border border-emerald-900 bg-emerald-950/30 px-4 py-3">
-              <span className="text-sm font-semibold text-emerald-100">Hex digest</span>
+            <label className={`${styles.optionRow} ${styles.hexRow}`}>
+              <span className={styles.optionLabel}>Hex digest</span>
               <input
                 type="checkbox"
                 checked={useHexDigest}
                 onChange={() => setUseHexDigest((current) => !current)}
-                className="h-5 w-5 accent-emerald-500"
+                className={`${styles.checkbox} ${styles.hexCheckbox}`}
               />
             </label>
           </section>

--- a/site/styles/password-generator.module.scss
+++ b/site/styles/password-generator.module.scss
@@ -1,0 +1,398 @@
+.page {
+  --pg-panel-bg: #ffffff;
+  --pg-panel-border: #d7dde6;
+  --pg-panel-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+  --pg-panel-divider: #e6ebf1;
+  --pg-surface-bg: #f8fbff;
+  --pg-input-bg: #fbfdff;
+  --pg-input-border: #cbd6e2;
+  --pg-input-text: #18324d;
+  --pg-heading-text: #1f2937;
+  --pg-label-text: #526176;
+  --pg-muted-text: #78869a;
+  --pg-row-bg: #f8fafc;
+  --pg-row-hover-bg: #f2f8ff;
+  --pg-disabled-bg: #f3f5f8;
+  --pg-primary: #0284c7;
+  --pg-primary-hover: #0369a1;
+  --pg-primary-soft: #e6f4ff;
+  --pg-primary-border: #7dd3fc;
+  --pg-success: #059669;
+  --pg-success-hover: #047857;
+  --pg-success-soft: #ecfdf5;
+  --pg-success-border: #a7f3d0;
+  --pg-error-bg: #fff1f2;
+  --pg-error-border: #fecdd3;
+  --pg-error-text: #be123c;
+}
+
+:global(.theme-dark) .page {
+  --pg-panel-bg: #20242c;
+  --pg-panel-border: #424a58;
+  --pg-panel-shadow: 0 20px 48px rgba(0, 0, 0, 0.24);
+  --pg-panel-divider: #303744;
+  --pg-surface-bg: #171b22;
+  --pg-input-bg: #151a22;
+  --pg-input-border: #4a5565;
+  --pg-input-text: #d7f0ff;
+  --pg-heading-text: #edf3fb;
+  --pg-label-text: #c7d1df;
+  --pg-muted-text: #98a4b6;
+  --pg-row-bg: #171b22;
+  --pg-row-hover-bg: #202a35;
+  --pg-disabled-bg: #1c2129;
+  --pg-primary: #38bdf8;
+  --pg-primary-hover: #0ea5e9;
+  --pg-primary-soft: rgba(56, 189, 248, 0.14);
+  --pg-primary-border: rgba(125, 211, 252, 0.52);
+  --pg-success: #34d399;
+  --pg-success-hover: #10b981;
+  --pg-success-soft: rgba(16, 185, 129, 0.14);
+  --pg-success-border: rgba(52, 211, 153, 0.5);
+  --pg-error-bg: rgba(159, 18, 57, 0.18);
+  --pg-error-border: rgba(251, 113, 133, 0.44);
+  --pg-error-text: #fda4af;
+}
+
+@media (prefers-color-scheme: dark) {
+  :global(html:not(.theme-light)) .page {
+    --pg-panel-bg: #20242c;
+    --pg-panel-border: #424a58;
+    --pg-panel-shadow: 0 20px 48px rgba(0, 0, 0, 0.24);
+    --pg-panel-divider: #303744;
+    --pg-surface-bg: #171b22;
+    --pg-input-bg: #151a22;
+    --pg-input-border: #4a5565;
+    --pg-input-text: #d7f0ff;
+    --pg-heading-text: #edf3fb;
+    --pg-label-text: #c7d1df;
+    --pg-muted-text: #98a4b6;
+    --pg-row-bg: #171b22;
+    --pg-row-hover-bg: #202a35;
+    --pg-disabled-bg: #1c2129;
+    --pg-primary: #38bdf8;
+    --pg-primary-hover: #0ea5e9;
+    --pg-primary-soft: rgba(56, 189, 248, 0.14);
+    --pg-primary-border: rgba(125, 211, 252, 0.52);
+    --pg-success: #34d399;
+    --pg-success-hover: #10b981;
+    --pg-success-soft: rgba(16, 185, 129, 0.14);
+    --pg-success-border: rgba(52, 211, 153, 0.5);
+    --pg-error-bg: rgba(159, 18, 57, 0.18);
+    --pg-error-border: rgba(251, 113, 133, 0.44);
+    --pg-error-text: #fda4af;
+  }
+}
+
+.title {
+  color: var(--darker-gray-color);
+}
+
+.panel {
+  border: 1px solid var(--pg-panel-border);
+  border-radius: 8px;
+  background: var(--pg-panel-bg);
+  box-shadow: var(--pg-panel-shadow);
+}
+
+.outputPanel {
+  margin-top: 1.5rem;
+  padding: 1rem;
+}
+
+.outputHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.9rem;
+  border-bottom: 1px solid var(--pg-panel-divider);
+}
+
+.panelLabel,
+.fieldLabel {
+  color: var(--pg-label-text);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.actionButton {
+  min-height: 2.5rem;
+  padding: 0.55rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 800;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+
+.actionButton:hover {
+  transform: translateY(-1px);
+}
+
+.actionButton:focus-visible,
+.presetButton:focus-visible,
+.numberInput:focus-visible,
+.passwordTextarea:focus-visible,
+.checkbox:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--pg-primary) 26%, transparent);
+  outline-offset: 2px;
+}
+
+.primaryAction {
+  background: var(--pg-success);
+  color: #ffffff;
+}
+
+.primaryAction:hover {
+  background: var(--pg-success-hover);
+}
+
+.secondaryAction {
+  border-color: var(--pg-primary-border);
+  background: var(--pg-primary-soft);
+  color: var(--pg-primary-hover);
+}
+
+.secondaryAction:hover {
+  border-color: var(--pg-primary);
+  color: var(--pg-primary);
+}
+
+.passwordField {
+  margin-top: 1rem;
+}
+
+.passwordTextarea {
+  width: 100%;
+  min-height: 8.5rem;
+  padding: 1rem;
+  border: 1px solid var(--pg-input-border);
+  border-radius: 8px;
+  background: var(--pg-input-bg);
+  color: var(--pg-input-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 1rem;
+  line-height: 1.65;
+  outline: none;
+  resize: vertical;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.passwordTextarea:focus {
+  border-color: var(--pg-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--pg-primary) 16%, transparent);
+}
+
+.metaBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.85rem;
+}
+
+.metaPill {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--pg-panel-border);
+  border-radius: 999px;
+  background: var(--pg-surface-bg);
+  color: var(--pg-muted-text);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.errorMessage {
+  margin-top: 0.85rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--pg-error-border);
+  border-radius: 8px;
+  background: var(--pg-error-bg);
+  color: var(--pg-error-text);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.controlGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .controlGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.controlGrid .panel {
+  padding: 1rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: var(--pg-heading-text);
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.presetGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.presetButton {
+  min-height: 2.5rem;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--pg-panel-border);
+  border-radius: 8px;
+  background: var(--pg-row-bg);
+  color: var(--pg-heading-text);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 800;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+
+.presetButton:hover {
+  border-color: var(--pg-primary-border);
+  background: var(--pg-row-hover-bg);
+  color: var(--pg-primary-hover);
+}
+
+.presetActive,
+.presetActive:hover {
+  border-color: var(--pg-primary);
+  background: var(--pg-primary);
+  color: #ffffff;
+}
+
+.fieldLabel {
+  display: block;
+  margin-top: 1.5rem;
+}
+
+.numberInput {
+  width: 100%;
+  margin-top: 0.6rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--pg-input-border);
+  border-radius: 8px;
+  background: var(--pg-input-bg);
+  color: var(--pg-heading-text);
+  font-size: 1rem;
+  font-weight: 650;
+  outline: none;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.numberInput:focus {
+  border-color: var(--pg-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--pg-primary) 16%, transparent);
+}
+
+.optionStack {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+
+.optionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 2.9rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--pg-panel-border);
+  border-radius: 8px;
+  background: var(--pg-row-bg);
+  cursor: pointer;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+}
+
+.optionRow:hover {
+  border-color: var(--pg-primary-border);
+  background: var(--pg-row-hover-bg);
+}
+
+.optionDisabled {
+  background: var(--pg-disabled-bg);
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.optionDisabled:hover {
+  border-color: var(--pg-panel-border);
+  background: var(--pg-disabled-bg);
+}
+
+.optionLabel {
+  color: var(--pg-heading-text);
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.checkbox {
+  width: 1.15rem;
+  height: 1.15rem;
+  flex: 0 0 auto;
+  accent-color: var(--pg-primary);
+  cursor: pointer;
+}
+
+.checkbox:disabled {
+  cursor: not-allowed;
+}
+
+.hexRow {
+  margin-top: 1rem;
+  border-color: var(--pg-success-border);
+  background: var(--pg-success-soft);
+}
+
+.hexRow:hover {
+  border-color: var(--pg-success);
+  background: var(--pg-success-soft);
+}
+
+.hexRow .optionLabel {
+  color: var(--pg-success-hover);
+}
+
+.hexCheckbox {
+  accent-color: var(--pg-success);
+}
+
+@media (max-width: 560px) {
+  .outputHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    justify-content: stretch;
+  }
+
+  .actionButton {
+    width: 100%;
+  }
+
+  .presetGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- Restyle the password generator with scoped light and dark theme variables.
- Move output actions into a cleaner header and replace hard-coded dark Tailwind blocks with theme-aware panels.
- Improve responsive spacing for the output, length presets, and character options.

## Validation
- npm test
- npm run build
- git diff --check
- npm exec eslint -- pages/projects/password-generator.js (blocked: repo has no ESLint configuration)